### PR TITLE
fix: error of dock

### DIFF
--- a/config/awesome/ui/dock/dock.lua
+++ b/config/awesome/ui/dock/dock.lua
@@ -48,7 +48,7 @@ local function helpers()
 		local B, K, OUT, I, D = 16, "0123456789ABCDEF", "", 0
 		while IN > 0 do
 			I = I + 1
-			IN, D = math.floor(IN / B), (IN % B) + 1
+			IN, D = math.floor(IN / B), math.floor((IN % B) + 1)
 			OUT = string.sub(K, D, D) .. OUT
 		end
 		return #OUT == 2 and OUT or "0" .. OUT


### PR DESCRIPTION
I saw there was an error for dock. So I fixed it.

```awesome: Error during a protected call: /home/archfeh/.config/awesome/ui/dock/dock.lua:52: bad argument #2 to 'sub' (number has no integer representation)```